### PR TITLE
Issue 2 customisable port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN /bin/bash -c "pip3 install --no-cache-dir -r <(pipenv lock -r)"
 
 ADD . /httpbin
 RUN pip3 install --no-cache-dir /httpbin
+RUN chmod +x /httpbin/httpbin.bash
 
 EXPOSE 80
 
-CMD ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]
+ENTRYPOINT ["/httpbin/httpbin.bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN chmod +x /httpbin/httpbin.bash
 
 EXPOSE 80
 
-ENTRYPOINT ["/httpbin/httpbin.bash"]
+CMD ["/httpbin/httpbin.bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update -y && apt install python3-pip git -y && pip3 install --no-cache-d
 
 ADD Pipfile Pipfile.lock /httpbin/
 WORKDIR /httpbin
-RUN /bin/bash -c "pip3 install --no-cache-dir -r <(pipenv lock -r)"
+RUN /bin/bash -c "pip3 install --no-cache-dir -r <(pipenv requirements)"
 
 ADD . /httpbin
 RUN pip3 install --no-cache-dir /httpbin

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ docker pull kennethreitz/httpbin
 docker run -p 80:80 kennethreitz/httpbin
 ```
 
+Some enviroments do not allow to bind to a privileged port. To run it on a
+different port instead of port 80, set the environment variables as follows:
+
+```sh
+docker run -e HTTPIN_PORT=8000 -p 8000:8000 kennethreitz/httpbin
+```
+
 See http://httpbin.org for more information.
 
 ## Officially Deployed at:

--- a/httpbin.bash
+++ b/httpbin.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+exec gunicorn \
+    -b ${HTTPBIN_HOST:-0.0.0.0}:${HTTPBIN_PORT:-80} \
+    -k gevent \
+    httpbin:app


### PR DESCRIPTION
Proposal for an entry-point that allows changing the port that is used inside the container.

This is slightly in conflict with the `EXPOSE` line from the Dockerfile. But it works nonetheless. For most people, port 80 works so that should not play a big role. I don't know of a way to make the `EXPOSE` line variable for new container start-ups as the EXPOSE line is used during the *build* phase.

An *alternative* solution would be to simply start it up on a non-privileged port by default. But that is non backwards-compatible and will break existing deployments.

I had to make a slight adjustment to the `pipenv` call to make it work with newer versions of `pipenv`