### PR TITLE
Fix auth incompatibility with Werkzeug 2.3.0+

### DIFF
--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -468,7 +468,7 @@ def digest_challenge_response(app, qop, algorithm, stale = False):
 
     auth = WWWAuthenticate("digest")
     auth.set_digest('me@kennethreitz.com', nonce, opaque=opaque,
-                    qop=('auth', 'auth-int') if qop is None else (qop,), algorithm=algorithm)
-    auth.stale = stale
+                    qop=('auth', 'auth-int') if qop is None else (qop,), algorithm=algorithm,
+                    stale=stale)
     response.headers['WWW-Authenticate'] = auth.to_header()
     return response


### PR DESCRIPTION
Two tests `test_digest_auth` and `test_digest_auth_wrong_pass` are failing when run against werkzeug 2.3.0+. This is because https://github.com/pallets/werkzeug/pull/2619 changed the internals of the WWWAuthenticate class so that it no longer has a directly exposed `stale` property.

Fortunately, it seems that even all the way back to werkzeug 0.14, the value of `stale` could be passed as an argument to the `set_digest` method, so we can do that to fix this issue. 