### PR TITLE
Don't pass bytes into get() method in test

### DIFF
--- a/tests/test_httpbin.py
+++ b/tests/test_httpbin.py
@@ -168,8 +168,8 @@ class HttpbinTestCase(unittest.TestCase):
 
     def test_base64(self):
         greeting = u'Здравствуй, мир!'
-        b64_encoded = _string_to_base64(greeting)
-        response = self.app.get(b'/base64/' + b64_encoded)
+        b64_encoded = _string_to_base64(greeting).decode('utf8')
+        response = self.app.get('/base64/' + b64_encoded)
         content = response.data.decode('utf-8')
         self.assertEqual(greeting, content)
 


### PR DESCRIPTION
The test `test_base64` fails in werkzeug 2.3.0+ after https://github.com/pallets/werkzeug/commit/42e898c108b46a7297196bf002bf5465a999a9e5. The internal `_wsgi_encoding_dance` function no longer accepts bytes. We can fix this by decoding the bytes on the way in.