### PR TITLE
Wheel build fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     include_package_data = True, # include files listed in MANIFEST.in
     install_requires=[
         'Flask', 'MarkupSafe', 'decorator', 'itsdangerous', 'brotlicffi',
-        'werkzeug', 'gevent', 'flasgger', 'jinja2'
+        'werkzeug', 'flasgger', 'jinja2'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
          'Programming Language :: Python :: 3.6',
     ],
     test_suite="test_httpbin",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     include_package_data = True, # include files listed in MANIFEST.in
     install_requires=[
         'Flask', 'MarkupSafe', 'decorator', 'itsdangerous', 'brotlicffi',


### PR DESCRIPTION
This PR fixes `setup.py` not to install `tests` as a package, and adds a minimal `pyproject.toml` to modernize the package a bit.

EDIT: also noticed stray `gevent` dependency now.