### PR TITLE
Enable pip caching for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install .


### PR DESCRIPTION
Enable pip caching in order to avoid repeatedly rebuilding all the PyPy wheels for source packages.  This is inspired by discussion in https://github.com/psf/requests/pull/6496 and it may help with the PyPy CI failures.