### PR TITLE
Consistently use positional parameter for path

### DIFF
--- a/tests/test_httpbin.py
+++ b/tests/test_httpbin.py
@@ -541,25 +541,25 @@ class HttpbinTestCase(unittest.TestCase):
             'TRACE',
         ]
         for m in methods:
-            response = self.app.open(path='/status/418', method=m)
+            response = self.app.open('/status/418', method=m)
             self.assertEqual(response.status_code, 418)
 
     def test_status_endpoint_invalid_code(self):
-        response = self.app.get(path='/status/4!9')
+        response = self.app.get('/status/4!9')
         self.assertEqual(response.status_code, 400)
 
     def test_status_endpoint_invalid_codes(self):
-        response = self.app.get(path='/status/200,402,foo')
+        response = self.app.get('/status/200,402,foo')
         self.assertEqual(response.status_code, 400)
 
     def test_xml_endpoint(self):
-        response = self.app.get(path='/xml')
+        response = self.app.get('/xml')
         self.assertEqual(
             response.headers.get('Content-Type'), 'application/xml'
         )
 
     def test_x_forwarded_proto(self):
-        response = self.app.get(path='/get', headers={
+        response = self.app.get('/get', headers={
             'X-Forwarded-Proto':'https'
         })
         assert json.loads(response.data.decode('utf-8'))['url'].startswith('https://')


### PR DESCRIPTION
This matches other call sites.