### PR TITLE
Template cleanup for homepages and docker URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a fork of the original httpbin project, which is located at https://gith
 
 Why fork?  we were unable to get ahold of the folks at postmanlabs to maintain the original project, and httpbin is used for other packages within the python ecosystem, such as [pytest-httpbin](https://pypi.org/project/pytest-httpbin/) which is in turn used by packages such as [requests](https://github.com/psf/requests/blob/main/requirements-dev.txt#L4) so we have forked this package.  That means that httpbin.org is not actually backed by this repo, but the [httpbin package](https://pypi.org/project/httpbin/) is.  Confusing right?  Know anyone at postmanlabs?  [get in touch](mailto:me@kevinmccarthy.org).
 
-httpbin is a [Kenneth Reitz](http://kennethreitz.org/bitcoin) Project.
+httpbin is a [Kenneth Reitz](http://kennethreitz.org/) Project.
 ![ice cream](http://farm1.staticflickr.com/572/32514669683_4daf2ab7bc_k_d.jpg)
 
 ## Downloading and Running

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -105,9 +105,9 @@ template = {
             "<code>$ docker run -p 80:8080 ghcr.io/psf/httpbin</code>"
         ),
         "contact": {
-            "responsibleOrganization": "Kenneth Reitz",
+            "responsibleOrganization": "Python Software Foundation",
             "responsibleDeveloper": "Kenneth Reitz",
-            "url": "https://kennethreitz.org",
+            "url": "https://github.com/psf/httpbin/",
         },
         # "termsOfService": "http://me.com/terms",
         "version": version,

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -107,7 +107,6 @@ template = {
         "contact": {
             "responsibleOrganization": "Kenneth Reitz",
             "responsibleDeveloper": "Kenneth Reitz",
-            "email": "me@kennethreitz.org",
             "url": "https://kennethreitz.org",
         },
         # "termsOfService": "http://me.com/terms",

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -100,7 +100,9 @@ template = {
         "title": "httpbin.org",
         "description": (
             "A simple HTTP Request & Response Service."
-            "<br/> <br/> <b>Run locally: </b> <code>$ docker run -p 80:80 kennethreitz/httpbin</code>"
+            "<br/> <br/> <b>Run locally: </b> <br/> "
+            "<code>$ docker pull ghcr.io/psf/httpbin</code> <br/>"
+            "<code>$ docker run -p 80:8080 ghcr.io/psf/httpbin</code>"
         ),
         "contact": {
             "responsibleOrganization": "Kenneth Reitz",

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -100,6 +100,7 @@ template = {
         "title": "httpbin.org",
         "description": (
             "A simple HTTP Request & Response Service."
+            "<br/> A <a href='http://kennethreitz.com/'>Kenneth Reitz</a> project."
             "<br/> <br/> <b>Run locally: </b> <br/> "
             "<code>$ docker pull ghcr.io/psf/httpbin</code> <br/>"
             "<code>$ docker run -p 80:8080 ghcr.io/psf/httpbin</code>"

--- a/httpbin/templates/flasgger/index.html
+++ b/httpbin/templates/flasgger/index.html
@@ -103,7 +103,6 @@
                                 <div>
                                     <a href="https://kennethreitz.org" target="_blank">the developer - Website</a>
                                 </div>
-                                <a href="mailto:me@kennethreitz.org">Send email to the developer</a>
                             </div>
                         </div>
                         <!-- ADDS THE LOADER SPINNER -->

--- a/httpbin/templates/flasgger/index.html
+++ b/httpbin/templates/flasgger/index.html
@@ -29,7 +29,7 @@
 </head>
 
 <body>
-    <a href="https://github.com/requests/httpbin" class="github-corner" aria-label="View source on Github">
+    <a href="https://github.com/psf/httpbin" class="github-corner" aria-label="View source on Github">
         <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"
             aria-hidden="true">
             <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
@@ -101,7 +101,7 @@
                             </div>
                             <div>
                                 <div>
-                                    <a href="https://kennethreitz.org" target="_blank">the developer - Website</a>
+                                    <a href="https://github.com/psf/httpbin/" target="_blank">the developer - Website</a>
                                 </div>
                             </div>
                         </div>

--- a/httpbin/templates/flasgger/index.html
+++ b/httpbin/templates/flasgger/index.html
@@ -85,11 +85,7 @@
                     <section class="block col-12">
                         <div class="info">
                             <hgroup class="main">
-                                <h2 class="title">httpbin.org
-                                    <small>
-                                        <pre class="version">0.9.2</pre>
-                                    </small>
-                                </h2>
+                                <h2 class="title">httpbin.org</h2>
                                 <pre class="base-url">[ Base URL: httpbin.org/ ]</pre>
                             </hgroup>
                             <div class="description">

--- a/httpbin/templates/flasgger/index.html
+++ b/httpbin/templates/flasgger/index.html
@@ -97,8 +97,9 @@
                                     <p>A simple HTTP Request &amp; Response Service.
                                         <br>
                                         <br>
-                                        <b>Run locally: </b>
-                                        <code>$ docker run -p 80:80 kennethreitz/httpbin</code>
+                                        <b>Run locally: </b> <br/>
+                                        <code>$ docker pull ghcr.io/psf/httpbin</code> <br/>
+                                        <code>$ docker run -p 80:8080 ghcr.io/psf/httpbin</code>
                                     </p>
                                 </div>
                             </div>

--- a/httpbin/templates/flasgger/index.html
+++ b/httpbin/templates/flasgger/index.html
@@ -91,6 +91,7 @@
                             <div class="description">
                                 <div class="markdown">
                                     <p>A simple HTTP Request &amp; Response Service.
+                                        <br/> A <a href='http://kennethreitz.com/'>Kenneth Reitz</a> project.
                                         <br>
                                         <br>
                                         <b>Run locally: </b> <br/>

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -140,6 +140,7 @@ $ gunicorn httpbin:app
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
+<p>Currently maintained on GitHub as <a href="https://github.com/psf/httpbin/">psf/httpbin</a> project.</p>
 <p>A <a href="http://kennethreitz.com/">Kenneth Reitz</a> project.</p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -141,7 +141,6 @@ $ gunicorn httpbin:app
 <h2 id="AUTHOR">AUTHOR</h2>
 
 <p>A <a href="http://kennethreitz.com/">Kenneth Reitz</a> project.</p>
-<p>BTC: <a href="https://www.kennethreitz.org/bitcoin"><code>1Me2iXTJ91FYZhrGvaGaRDCBtnZ4KdxCug</code></a></p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -1,12 +1,5 @@
 <div class='mp'>
 <h1>httpbin(1): HTTP Request &amp; Response Service</h1>
-<p>Freely hosted in <a href="http://httpbin.org">HTTP</a>, <a href="https://httpbin.org">HTTPS</a>, &amp; <a href="http://eu.httpbin.org/">EU</a> flavors by <a href="http://kennethreitz.org/bitcoin">Kenneth Reitz</a> &amp; <a href="https://www.heroku.com/python">Heroku</a>.</p>
-
-<h2 id="BONUSPOINTS">BONUSPOINTS</h2>
-
-<ul>
-<li><a href="https://now.httpbin.org/" data-bare-link="true"><code>now.httpbin.org</code></a> The current time, in a variety of formats.</li>
-</ul>
 
 <h2 id="ENDPOINTS">ENDPOINTS</h2>
 

--- a/httpbin/templates/index.html
+++ b/httpbin/templates/index.html
@@ -231,7 +231,7 @@
 </head>
 
 <body id='manpage'>
-  <a href="https://github.com/requests/httpbin" class="github-corner" aria-label="View source on Github">
+  <a href="https://github.com/psf/httpbin" class="github-corner" aria-label="View source on Github">
     <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"
       aria-hidden="true">
       <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>


### PR DESCRIPTION
Update the templates to avoid giving dead/unmaintained/confusing links and update the docker URLs:

- remove the links to the public httpbin instances from the legacy template since they're all running the old version or are entirely dead
- use this repository as the "GitHub corner" and homepage
- add/keep a "Kenneth Reitz project" link for the original attribution
- remove bitcoin because the link is dead and the id may no longer be valid
- remove version from "base template" used by swagger while the page is loading because it's unnecessary and an unnecessary maintenance effort
- update the docker instructions in templates based on README

That said, the docker instructions don't really work for me:

```
$ docker pull ghcr.io/psf/httpbin
Using default tag: latest
Error response from daemon: Head "https://ghcr.io/v2/psf/httpbin/manifests/latest": denied
```