### PR TITLE
Extract publish pipeline to remove matrix issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: Run CI
 
 on: [push, pull_request]
 
-permissions:
-  contents: write
-  packages: write
-
 jobs:
   unit-tests:
     runs-on: ${{ matrix.os }}
@@ -44,13 +40,6 @@ jobs:
         python -m pip install .[test]
     - name: Run tests
       run: tox
-    - name: Create GitHub Release
-      if: startsWith(github.ref, 'refs/tags/release-') && github.event_name == 'push'
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          requirements.txt
-          Dockerfile
     - name: Store tested requirements.txt file as artifact
       uses: actions/upload-artifact@v3
       with:
@@ -79,50 +68,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: requirements.txt
-      - name: Build Image
+      - name: Ensure docker build is working
         run: >
           docker build
           --build-arg "APP_VERSION=${APP_VERSION}"
           --build-arg "APP_DESC=${APP_DESC}"
-          -t "ghcr.io/${GITHUB_REPOSITORY}:${APP_VERSION}"
-          -t "ghcr.io/${GITHUB_REPOSITORY}:latest"
           .
-
-      # - name: Login to Docker Hub
-      #   if: github.event_name == 'push'
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GHCR
-        if: startsWith(github.ref, 'refs/tags/release-') && github.event_name == 'push'
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push Docker Image
-        if: startsWith(github.ref, 'refs/tags/release-') && github.event_name == 'push'
-        run: |
-          docker push "ghcr.io/${GITHUB_REPOSITORY}:${APP_VERSION}"
-
-  pypi-publish:
-    needs: [unit-tests]
-    if: startsWith(github.ref, 'refs/tags/release-') && github.event_name == 'push'
-    name: Upload release to PyPI
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/httpbin
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build distribution
-        run: |
-          python -m pip install --upgrade pip build
-          pyproject-build
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,98 @@
+---
+name: Publish
+on: [push]
+permissions:
+  contents: write
+  packages: write
+jobs:
+  unit-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Set up environment & install dependencies
+        run: |
+          python -m pip install pip-tools
+          pip-compile --quiet --generate-hashes --extra mainapp > requirements.txt
+          python -m pip install --requirement requirements.txt
+          python -m pip install .[test]
+      - name: Run tests
+        run: tox
+      - name: Check file contents
+        run: cat requirements.txt
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/release-')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            requirements.txt
+            Dockerfile
+      - name: Store tested requirements.txt file as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: requirements.txt
+          path: |
+            requirements.txt
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    needs: [unit-tests]
+    steps:
+      - name: System Dependencies for Packaging
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip python3-venv
+          python3 -m venv /tmp/tomlq
+          /tmp/tomlq/bin/pip install --upgrade pip
+          /tmp/tomlq/bin/pip install yq
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set Environment
+        run: |
+          echo "APP_VERSION=$(/tmp/tomlq/bin/tomlq -r .project.version pyproject.toml)" >> $GITHUB_ENV
+          echo "APP_DESC=$(/tmp/tomlq/bin/tomlq -r .project.description pyproject.toml)" >> $GITHUB_ENV
+      - name: Retrieve tested requirements file
+        uses: actions/download-artifact@v3
+        with:
+          name: requirements.txt
+      - name: Check file contents
+        run: cat requirements.txt
+      - name: Build Image
+        run: >
+          docker build
+          --build-arg "APP_VERSION=${APP_VERSION}"
+          --build-arg "APP_DESC=${APP_DESC}"
+          -t "ghcr.io/${GITHUB_REPOSITORY}:${APP_VERSION}"
+          -t "ghcr.io/${GITHUB_REPOSITORY}:latest"
+          .
+      - name: Login to GHCR
+        if: startsWith(github.ref, 'refs/tags/release-')
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push Docker Image
+        if: startsWith(github.ref, 'refs/tags/release-')
+        run: |
+          docker push "ghcr.io/${GITHUB_REPOSITORY}:${APP_VERSION}"
+  pypi-publish:
+    needs: [unit-tests]
+    if: startsWith(github.ref, 'refs/tags/release-')
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/httpbin
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build distribution
+        run: |
+          python -m pip install --upgrade pip build
+          pyproject-build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR splits out the "publish" jobs from the CI pipeline.

The previous pipeline used a "matrix" execution to run unit-tests across several operating-systems and Python versions. Each "cell" of that matrix generated its own `requirements.txt` file and uploaded it as artifact. As these jobs ran in parallel, it is likely that this caused the issue that surfaced in #23.

I *suspect* that this fixes it.

It has the additional bonus that we don't accidentally use a `requirements.txt` from a Windows/Python3.9 environment to create the docker image (which runs on Linux/Python3.10).

This has the only downside that the pipeline which publishes the package only runs on one Python version on one system. But it is safe to assume that the full matrix has already run prior to actually _tagging_ a release.