### PR TITLE
Support Flask 3.0

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -32,7 +32,13 @@ try:
     from werkzeug.wrappers import Response
 except ImportError:  # werkzeug < 2.1
     from werkzeug.wrappers import BaseResponse as Response
-from werkzeug.http import parse_authorization_header
+
+try:
+    from werkzeug.http import parse_authorization_header
+except ImportError: # werkzeug < 2.3
+    from werkzeug.datastructures import Authorization
+    parse_authorization_header = Authorization.from_header
+
 from flasgger import Swagger, NO_SANITIZER
 
 from . import filters

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -33,12 +33,6 @@ try:
 except ImportError:  # werkzeug < 2.1
     from werkzeug.wrappers import BaseResponse as Response
 
-try:
-    from werkzeug.http import parse_authorization_header
-except ImportError: # werkzeug < 2.3
-    from werkzeug.datastructures import Authorization
-    parse_authorization_header = Authorization.from_header
-
 from flasgger import Swagger, NO_SANITIZER
 
 from . import filters
@@ -53,6 +47,7 @@ from .helpers import (
     H,
     ROBOT_TXT,
     ANGRY_ASCII,
+    parse_authorization_header,
     parse_multi_value_header,
     next_stale_after_value,
     digest_challenge_response,
@@ -642,16 +637,13 @@ def redirect_to():
     args_dict = request.args.items()
     args = CaseInsensitiveDict(args_dict)
 
-    # We need to build the response manually and convert to UTF-8 to prevent
-    # werkzeug from "fixing" the URL. This endpoint should set the Location
-    # header to the exact string supplied.
     response = app.make_response("")
     response.status_code = 302
     if "status_code" in args:
         status_code = int(args["status_code"])
         if status_code >= 300 and status_code < 400:
             response.status_code = status_code
-    response.headers["Location"] = args["url"].encode("utf-8")
+    response.headers["Location"] = args["url"]
 
     return response
 

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -13,8 +13,14 @@ import re
 import time
 import os
 from hashlib import md5, sha256, sha512
-from werkzeug.http import parse_authorization_header
 from werkzeug.datastructures import WWWAuthenticate
+from werkzeug.http import dump_header
+
+try:
+    from werkzeug.http import parse_authorization_header
+except ImportError: # werkzeug < 2.3
+    from werkzeug.datastructures import Authorization
+    parse_authorization_header = Authorization.from_header
 
 from flask import request, make_response
 from six.moves.urllib.parse import urlparse, urlunparse
@@ -466,9 +472,14 @@ def digest_challenge_response(app, qop, algorithm, stale = False):
     ]), algorithm)
     opaque = H(os.urandom(10), algorithm)
 
-    auth = WWWAuthenticate("digest")
-    auth.set_digest('me@kennethreitz.com', nonce, opaque=opaque,
-                    qop=('auth', 'auth-int') if qop is None else (qop,), algorithm=algorithm)
-    auth.stale = stale
+    values = {
+        'realm': 'me@kennethreitz.com',
+        'nonce': nonce,
+        'opaque': opaque,
+        'qop': dump_header(('auth', 'auth-int') if qop is None else (qop,)),
+        'algorithm': algorithm,
+        'stale': stale,
+    }
+    auth = WWWAuthenticate("digest", values=values)
     response.headers['WWW-Authenticate'] = auth.to_header()
     return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,13 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "Flask",
+    "flask >= 2.2.4",
     "brotlicffi",
     "decorator",
     "flasgger",
     'greenlet < 3.0; python_version<"3.12"',
     'greenlet >= 3.0.0a1; python_version>="3.12.0rc0"',
     'importlib-metadata; python_version<"3.8"',
-    "werkzeug >= 0.14.1",
     "six",
 ]
 


### PR DESCRIPTION
This PR should get httpbin working with Flask 3.0. The other recent changes to get Flask 2.0 working in `main` already broke Flask<2.2.4 so I've updated the dependencies to correctly reflect what we're compatible with. This should also resolve #28.

This PR changes three primary pieces:

1. Move to using the WWWAuthenticate constructor that was introduced in werkzeug 2.0 and became the only supported interface in werkzeug 3.0.
2. Move to `Authorization.from_header` which was introduced in werkzeug 2.3 and is the only supported interface in werkzeug 3.0. `parse_authorization_header` was already [an alias](https://github.com/pallets/werkzeug/blob/f2e0ac6e915285cd39d72ae9e83eec5159d989cd/src/werkzeug/http.py#L814-L836) for this in versions of werkzeug we support.
3. We were doing some unneeded byte conversion for the Location header on redirect. This was a legacy change from 10 years ago to accommodate werkzeug casting all headers to `str` so we ensured they were `utf-8` bytes. werkzeug stopped this conversion in 3.0 and we already have a Python 3 `utf-8` string as input. We should be able drop this safely with our support range.