### PR TITLE
fix: OpenAPI spec invalid

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Patches and Suggestions
 - Dave Challis (https://github.com/davechallis)
 - Florian Bruhin (https://github.com/The-Compiler)
 - Brett Randall (https://github.com/javabrett)
+- Harold Ozouf (https://github.com/jspdown)

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -547,7 +547,8 @@ def redirect_n_times(n):
     parameters:
       - in: path
         name: n
-        type: int
+        type: number
+        required: true
     produces:
       - text/html
     responses:
@@ -589,7 +590,7 @@ def redirect_to():
           required: true
         - in: query
           name: status_code
-          type: int
+          type: number
     post:
       consumes:
         - application/x-www-form-urlencoded
@@ -600,7 +601,7 @@ def redirect_to():
           required: true
         - in: formData
           name: status_code
-          type: int
+          type: number
           required: false
     patch:
       consumes:
@@ -612,7 +613,7 @@ def redirect_to():
           required: true
         - in: formData
           name: status_code
-          type: int
+          type: number
           required: false
     put:
       consumes:
@@ -624,7 +625,7 @@ def redirect_to():
           required: true
         - in: formData
           name: status_code
-          type: int
+          type: number
           required: false
     responses:
       302:
@@ -654,7 +655,8 @@ def relative_redirect_n_times(n):
     parameters:
       - in: path
         name: n
-        type: int
+        type: number
+        required: true
     produces:
       - text/html
     responses:
@@ -684,7 +686,8 @@ def absolute_redirect_n_times(n):
     parameters:
       - in: path
         name: n
-        type: int
+        type: number
+        required: true
     produces:
       - text/html
     responses:
@@ -709,7 +712,8 @@ def stream_n_messages(n):
     parameters:
       - in: path
         name: n
-        type: int
+        type: number
+        required: true
     produces:
       - application/json
     responses:
@@ -738,6 +742,8 @@ def view_status_code(codes):
     parameters:
       - in: path
         name: codes
+        type: string
+        required: true
     produces:
       - text/plain
     responses:
@@ -864,9 +870,11 @@ def set_cookie(name, value):
       - in: path
         name: name
         type: string
+        required: true
       - in: path
         name: value
         type: string
+        required: true
     produces:
       - text/plain
     responses:
@@ -952,9 +960,11 @@ def basic_auth(user="user", passwd="passwd"):
       - in: path
         name: user
         type: string
+        required: true
       - in: path
         name: passwd
         type: string
+        required: true
     produces:
       - application/json
     responses:
@@ -980,9 +990,11 @@ def hidden_basic_auth(user="user", passwd="passwd"):
       - in: path
         name: user
         type: string
+        required: true
       - in: path
         name: passwd
         type: string
+        required: true
     produces:
       - application/json
     responses:
@@ -1006,8 +1018,7 @@ def bearer_auth():
     parameters:
       - in: header
         name: Authorization
-        schema:
-          type: string
+        type: string
     produces:
       - application/json
     responses:
@@ -1039,12 +1050,15 @@ def digest_auth_md5(qop=None, user="user", passwd="passwd"):
         name: qop
         type: string
         description: auth or auth-int
+        required: true
       - in: path
         name: user
         type: string
+        required: true
       - in: path
         name: passwd
         type: string
+        required: true
     produces:
       - application/json
     responses:
@@ -1067,17 +1081,21 @@ def digest_auth_nostale(qop=None, user="user", passwd="passwd", algorithm="MD5")
         name: qop
         type: string
         description: auth or auth-int
+        required: true
       - in: path
         name: user
         type: string
+        required: true
       - in: path
         name: passwd
         type: string
+        required: true
       - in: path
         name: algorithm
         type: string
         description: MD5, SHA-256, SHA-512
         default: MD5
+        required: true
     produces:
       - application/json
     responses:
@@ -1103,21 +1121,26 @@ def digest_auth(
         name: qop
         type: string
         description: auth or auth-int
+        required: true
       - in: path
         name: user
         type: string
+        required: true
       - in: path
         name: passwd
         type: string
+        required: true
       - in: path
         name: algorithm
         type: string
         description: MD5, SHA-256, SHA-512
         default: MD5
+        required: true
       - in: path
         name: stale_after
         type: string
         default: never
+        required: true
     produces:
       - application/json
     responses:
@@ -1202,7 +1225,8 @@ def delay_response(delay):
     parameters:
       - in: path
         name: delay
-        type: int
+        type: number
+        required: true
     produces:
       - application/json
     responses:
@@ -1299,6 +1323,7 @@ def decode_base64(value):
         name: value
         type: string
         default: SFRUUEJJTiBpcyBhd2Vzb21l
+        required: true
     produces:
       - text/html
     responses:
@@ -1321,8 +1346,10 @@ def cache():
     parameters:
       - in: header
         name: If-Modified-Since
+        type: string
       - in: header
         name: If-None-Match
+        type: string
     produces:
       - application/json
     responses:
@@ -1352,10 +1379,16 @@ def etag(etag):
     tags:
       - Response inspection
     parameters:
+      - in: path
+        name: etag
+        type: string
+        required: true
       - in: header
         name: If-None-Match
+        type: string
       - in: header
         name: If-Match
+        type: string
     produces:
       - application/json
     responses:
@@ -1392,7 +1425,8 @@ def cache_control(value):
     parameters:
       - in: path
         name: value
-        type: integer
+        type: number
+        required: true
     produces:
       - application/json
     responses:
@@ -1429,7 +1463,8 @@ def random_bytes(n):
     parameters:
       - in: path
         name: n
-        type: int
+        type: number
+        required: true
     produces:
       - application/octet-stream
     responses:
@@ -1460,7 +1495,8 @@ def stream_random_bytes(n):
     parameters:
       - in: path
         name: n
-        type: int
+        type: number
+        required: true
     produces:
       - application/octet-stream
     responses:
@@ -1504,7 +1540,8 @@ def range_request(numbytes):
     parameters:
       - in: path
         name: numbytes
-        type: int
+        type: number
+        required: true
     produces:
       - application/octet-stream
     responses:
@@ -1594,10 +1631,12 @@ def link_page(n, offset):
     parameters:
       - in: path
         name: n
-        type: int
+        type: number
+        required: true
       - in: path
         name: offset
-        type: int
+        type: number
+        required: true
     produces:
       - text/html
     responses:

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -107,9 +107,7 @@ template = {
             "<code>$ docker run -p 80:8080 ghcr.io/psf/httpbin</code>"
         ),
         "contact": {
-            "responsibleOrganization": "Python Software Foundation",
-            "responsibleDeveloper": "Kenneth Reitz",
-            "url": "https://github.com/psf/httpbin/",
+            "url": "https://kennethreitz.org",
         },
         # "termsOfService": "http://me.com/terms",
         "version": version,

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -115,7 +115,6 @@ template = {
     "host": "httpbin.org",  # overrides localhost:5000
     "basePath": "/",  # base bash for blueprint registration
     "schemes": ["https"],
-    "protocol": "https",
     "tags": [
         {
             "name": "HTTP Methods",


### PR DESCRIPTION
This PR fixes the generated OpenAPI spec document to be v2.0 compliant.  

The most important changes are the removal of the deprecated/non-standard SmartAPI fields `responsibleOrganization` and `responsibleDeveloper`. And the removal of the non-standard `protocol` field at the top level.

These fields alone prevented the use of HTTPBin spec on most OAS compliant tooling.

This PR was originally opened on https://github.com/postmanlabs/httpbin/pull/710 but this remote seems to not be maintained anymore. 