### PR TITLE
Use brotli with CPython, brotlicffi elsewhere

### DIFF
--- a/httpbin/filters.py
+++ b/httpbin/filters.py
@@ -10,7 +10,10 @@ This module provides response filter decorators.
 import gzip as gzip2
 import zlib
 
-import brotlicffi as _brotli
+try:
+    import brotlicffi as _brotli
+except ImportError:
+    import brotli as _brotli
 
 from six import BytesIO
 from decimal import Decimal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "brotlicffi",
+    "brotli; platform_python_implementation == 'CPython'",
+    "brotlicffi; platform_python_implementation != 'CPython'",
     "decorator",
     "flasgger",
     "flask >= 2.2.4",


### PR DESCRIPTION
[Upstream recommends](https://pypi.org/project/brotlicffi/) using the standard `brotli` package with CPython, relying on the CFFI alternative only on other platforms. Changes in this PR follow these recommendations.