### PR TITLE
Replace deprecated JSONIFY_PRETTYPRINT_REGULAR usage

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -89,7 +89,7 @@ tmpl_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
 
 app = Flask(__name__, template_folder=tmpl_dir)
 app.debug = bool(os.environ.get("DEBUG"))
-app.config["JSONIFY_PRETTYPRINT_REGULAR"] = True
+app.json.compact = False
 
 app.add_template_global("HTTPBIN_TRACKING" in os.environ, name="tracking_enabled")
 


### PR DESCRIPTION
This was deprecated in 2.2.0, and is gone in 2.3.0. We already require 2.2.4 or higher. The deprecation notice says to set `app.json.compact` instead, so we'll do that!