### PR TITLE
Fix /bytes endpoint with newer werkzeug versions

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -1449,7 +1449,7 @@ def random_bytes(n):
     response = make_response()
 
     # Note: can't just use os.urandom here because it ignores the seed
-    response.data = bytearray(random.randint(0, 255) for i in range(n))
+    response.data = bytes(random.randint(0, 255) for i in range(n))
     response.content_type = "application/octet-stream"
     return response
 


### PR DESCRIPTION
At some point, werkzeug starting checking the inputs to the write() method, which caused the following traceback:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/werkzeug/serving.py", line 364, in run_wsgi
    execute(self.server.app)
  File "/usr/lib/python3/dist-packages/werkzeug/serving.py", line 328, in execute
    write(data)
  File "/usr/lib/python3/dist-packages/werkzeug/serving.py", line 296, in write
    assert isinstance(data, bytes), "applications must write bytes"
AssertionError: applications must write bytes

Fix this by using bytes instead of bytearray.