### PR TITLE
contributor specific settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .local
 # to not include vscode configfolder in pushes / merges / pull requests
 .vscode
+.venv
 # Starting from here: ignore of official maintainers
 env/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Contributer ignore: where all local testing / learning stuff should be located
+# in this directory, to not be included in pushes / merges / pull requests
+.local
+# to not include vscode configfolder in pushes / merges / pull requests
+.vscode
+# Starting from here: ignore of official maintainers
 env/
 build/
 dist/
@@ -8,4 +14,3 @@ dist/
 *.pyc
 *.egg-info
 *.swp
-.vscode/


### PR DESCRIPTION
Like described in the issue, it would be great if you could accept this pull request to establish a reliable place for contributors to exist in the upstream location without the need of local patches for the .gitignore file

closes #48 