### PR TITLE
Fix CI test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.9", "pypy-3.10"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
+        # Python 3.8 and 3.9 do not run on macOS-latest which
+        # is now using arm64 hardware.
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+        exclude:
+        - { python-version: "3.8", os: "macos-latest" }
+        - { python-version: "3.9", os: "macos-latest" }
+        include:
+        - { python-version: "3.8", os: "macos-13" }
+        - { python-version: "3.9", os: "macos-13" }
 
     steps:
     - uses: actions/checkout@v3
@@ -36,10 +45,10 @@ jobs:
       run: |
         python -m pip install pip-tools
         pip-compile --quiet --generate-hashes --extra mainapp > requirements.txt
-        python -m pip install --requirement requirements.txt
-        python -m pip install .[test]
+        python -m pip install --use-pep517 --requirement requirements.txt
+        python -m pip install --use-pep517 .[test]
     - name: Run tests
-      run: tox
+      run: python -m pytest tests
     - name: Store tested requirements.txt file as artifact
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
This PR moves us off the tox runner to use `pytest` directly. We can also set up the support matrix to pass a `-e` parameter to tox to only invoke the correct environment, but that's a bit more involved. This PR will get the CI suite running correctly again so we can resolve #51. If someone is opinionated on keeping tox in the CI suite, we can address that in a follow up PR.

This also removed Python 3.7 from our support matrix since there is no longer a supported test runner in `actions/setup-python`.